### PR TITLE
typo in sha256-hash fixed

### DIFF
--- a/packages/windsurf/update-windsurf.sh
+++ b/packages/windsurf/update-windsurf.sh
@@ -61,7 +61,7 @@ update_package() {
     local default_nix="$SCRIPT_DIR/default.nix"
     sed -i "s/version = \".*\"/version = \"$version\"/" "$default_nix"
     sed -i "s|/stable/[a-f0-9]\{40\}/|/stable/$commit_hash/|" "$default_nix"
-		sed -i "s/x86_64-linux = \".*\"/x86_64-linux = \"$sha256_hashes\"/" "$default_nix"
+		sed -i "s/x86_64-linux = \".*\"/x86_64-linux = \"$sha256_hash\"/" "$default_nix"
 
     echo "Update complete!"
 }


### PR DESCRIPTION
In `update-windsurf.sh`, there was a typo in `update_package` where the variable was called `sha256_hash` but in the sed step it was being called as `sha256_hashes`