### PR TITLE
refactor(preservation): simplify module with tier system and per-user…

### DIFF
--- a/systems/aarch64-linux/oranix/default.nix
+++ b/systems/aarch64-linux/oranix/default.nix
@@ -35,7 +35,10 @@ in
 
     system = {
       enable = true;
-      preservation = enabled;
+      preservation = {
+        enable = true;
+        tier = "minimal";
+      };
     };
 
     tools = {

--- a/systems/x86_64-linux/DG-PC/default.nix
+++ b/systems/x86_64-linux/DG-PC/default.nix
@@ -52,7 +52,35 @@ in
       environment.sessionVariables = {
         CODEX_HOME = "$HOME/.config/codex";
       };
-      preservation = enabled;
+      preservation = {
+        enable = true;
+        users.dtgagnon = {
+          directories = [
+            "myVMs"
+            "nix-config"
+            "proj"
+            ".claude"
+            ".config"
+            ".config/discord"
+            ".config/hypr"
+            ".config/obsidian"
+            ".config/rofi"
+            ".config/syncthing"
+            ".config/VSCodium"
+            ".icons"
+            ".local/share/activitywatch"
+            ".local/share/bottles"
+            ".local/share/direnv"
+            ".local/share/keyrings"
+            ".local/share/rofi"
+            ".local/share/zoxide"
+            ".thunderbird"
+            ".vscode-oss"
+            "vfio-vm-info"
+          ];
+          files = [ ".claude.json" ];
+        };
+      };
     };
 
     tools = {

--- a/systems/x86_64-linux/slim/default.nix
+++ b/systems/x86_64-linux/slim/default.nix
@@ -102,6 +102,7 @@ in
     system.enable = true;
     system.preservation = {
       enable = true;
+      tier = "server";
       extraSysDirs = [
         "/var/lib/coolify"
         "/var/lib/caddy"


### PR DESCRIPTION
… config

Add tiered persistence (minimal, server, full) to replace complex feature flags:
- minimal: Core system only (machine-id, nixos, logs, ssh keys)
- server: Minimal + common server needs (gnupg, pki, nix state)
- full: Everything including desktop apps (default for backward compat)

Add exclusion options to remove specific items from tier defaults. Add per-user configuration option to replace hardcoded user blocks.

Update host configs:
- DG-PC: Move dtgagnon items to users option
- slim: Use server tier
- oranix: Use minimal tier